### PR TITLE
Create songs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,8 +41,10 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'pg'
 gem 'scrivener'
+gem 'scoped-concerns'
 
 group :test do
   gem "minitest"
   gem "minitest-rails"
+  gem "spawn"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,9 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    scoped-concerns (0.1.0)
     scrivener (1.1.1)
+    spawn (0.1.4)
     spring (2.1.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -158,7 +160,9 @@ DEPENDENCIES
   pg
   puma (~> 5.0)
   rails (~> 6.1.3, >= 6.1.3.1)
+  scoped-concerns
   scrivener
+  spawn
   spring
   sqlite3 (~> 1.4)
   tzinfo-data

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -13,6 +13,6 @@ module Response
   end
 
   def json_error(message = "Internal Server Error", extra_headers = {})
-    json_response({ message: message }, :error, extra_headers)
+    json_response({ message: message }, :internal_server_error, extra_headers)
   end
 end

--- a/app/controllers/concerns/songs/create_song.rb
+++ b/app/controllers/concerns/songs/create_song.rb
@@ -1,0 +1,49 @@
+module Songs
+  class CreateSong
+    include Scoped::Concern
+
+    def initialize(attrs = {})
+      @name = attrs[:name]
+      @duration = attrs[:duration]
+      @genre = attrs[:genre]
+      @album_ids = attrs[:albums]
+      @artists = attrs[:artists]
+    end
+
+    def run
+      begin
+        ActiveRecord::Base.transaction do
+          @song = Song.create(name: @name, duration: @duration, genre: @genre.to_sym)
+
+          if @artists.any?
+            @artists.each do |art|
+              if art[:id]
+                artist = Artist.find(art[:id])
+              else
+                artist = Artist.create(art)
+              end
+
+              artist.add_song(@song)
+
+              # Needed to refresh association from the database
+              @song.reload
+            end
+          end
+
+          if @album_ids.any?
+            albums = Album.where(id: @album_ids)
+
+            albums.each do |album|
+              album.add_song(@song)
+            end
+          end
+
+        end
+
+        success(song: @song)
+      rescue => e
+        error(create_song: e.message, backtrace: e.backtrace.join("\n"))
+      end
+    end
+  end
+end

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -1,0 +1,36 @@
+require_relative "../../lib/validators/create_song"
+require_relative "../../lib/presenters/song"
+
+class SongsController < ApplicationController
+  include Songs
+
+  def create
+    validator = Validators::CreateSong.new(song_params)
+
+    return json_bad_request(validator.errors) unless validator.valid?
+
+    create_song = Songs::CreateSong.run(validator.attributes)
+
+    if create_song.success?
+      presenter = Presenters::Song.new(create_song.result[:song])
+      json_created(presenter.show)
+    else
+      logger.error(create_song.errors)
+      json_error
+    end
+  end
+
+  private
+  def song_params
+    allowed = params.permit(:name, :duration, :genre,
+                            albums: [], artists: [:id, :name, :biography])
+
+    {
+      name: allowed[:name],
+      duration: allowed[:duration],
+      genre: allowed[:genre],
+      albums: allowed[:albums],
+      artists:  allowed[:artists]&.map(&:to_h)
+    }
+  end
+end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -2,4 +2,22 @@ class Album < ApplicationRecord
   validates :name, presence: true
   validates :total_duration, numericality: true
   validates :year, presence: true, numericality: true
+
+  def add_song(song)
+    self.cached_songs ||= {}
+
+    songs = self.cached_songs.tap do |cached|
+      cached[song.id] = {
+        name: song.name,
+        duration: song.duration,
+        genre: song.genre,
+        artists: song.artists.map(&:name)
+      }
+    end
+
+    self.update(
+      total_duration: self.total_duration + song.duration,
+      cached_songs: songs
+    )
+  end
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,3 +1,8 @@
 class Artist < ApplicationRecord
   has_one :artist_balance
+  has_and_belongs_to_many :songs
+
+  def add_song(song)
+    self.songs << song
+  end
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,5 +1,8 @@
 class Song < ApplicationRecord
-  enum genre: [:alternative_rock, :blues, :classical,
-              :country, :electronic, :funk, :heavy_metal,
-              :hip_hop, :jazz, :pop, :reggae, :soul, :rock]
+  enum genre: { alternative_rock: "alternative_rock", blues: "blues", classical: "classical",
+              country: "country", electronic: "electronic", funk: "funk", heavy_metal: "heavy_metal",
+              hip_hop: "hip_hop", jazz: "jazz", pop: "pop",
+              reggae: "reggae", soul: "soul", rock: "rock" }
+
+  has_and_belongs_to_many :artists
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resource :albums, only: [:create]
+  resource :songs, only: [:create]
 end

--- a/db/migrate/20210501115038_create_songs.rb
+++ b/db/migrate/20210501115038_create_songs.rb
@@ -8,11 +8,12 @@ class CreateSongs < ActiveRecord::Migration[6.1]
       t.string :name
       t.integer :duration
       t.integer :streams
+      t.string :genre, index: true
 
       t.timestamps
     end
 
-    add_column :songs, :genre, :genre, index: true
+    #add_column :songs, :genre, :genre, index: true
   end
 
   def down

--- a/db/migrate/20210508225748_create_artists_songs.rb
+++ b/db/migrate/20210508225748_create_artists_songs.rb
@@ -1,0 +1,8 @@
+class CreateArtistsSongs < ActiveRecord::Migration[6.1]
+  def change
+    create_table :artists_songs, id: false do |t|
+      t.belongs_to :artist
+      t.belongs_to :song
+    end
+  end
+end

--- a/docs/songs.md
+++ b/docs/songs.md
@@ -1,0 +1,69 @@
+# Songs API
+
+This document describes the `/songs` API.
+
+## Create Song
+
+`POST /songs`
+
+Creates a song record. Besides the song attributes, this endpoint also accepts an array of album IDs to associate with the song and a collection of artists information.
+If an entry in the artist information contains the `:id` key, the rest of the attributes of that entry will be ignored an the song will be associated with an artist identified with that ID if exists. Otherwise a `400 Bad Request` response will be retruned. If there's no `:id` key, a new artist will be created with the `:name` and `:biography` attributes.
+
+The following attributes are supported in a JSON request body:
+
+* `name`: Song name. String. Required.
+* `duration`: Duration of the song in seconds. Integer. Required
+* `genre`: Genre of the song. One of the following options: `alternative_rock`, `blues`, `classical`,`country`, `electronic`, `funk`, `heavy_metal`, `hip_hop`, `jazz`, `pop`, `reggae`, `soul`, `rock`
+. String. Required
+* `albums`: Collection of album IDs to associate with the song. Array. Required.
+* `artists`: Collection of artist information to associate with the song. See conditions in the description. Hash. Required
+
+### Request
+```
+POST /songs
+
+Content-type: application/json
+
+{
+  "name": "Wicked Garden",
+  "duration": 245,
+  "genre": "alternative_rock",
+  "albums": [98, 30],
+  "artists": [{ "name": "Stone Temple Pilots", "biography": "Best alternative rock band ever" }, { "id": 120 }]
+}
+```
+
+### Responses
+
+#### Success
+```
+201 Created
+Content-type: application/json; charset=utf-8
+
+{
+  "id": 102,
+  "name": "Wicked Garden",
+  "duration": 245,
+  "genre": "alternative_rock",
+  "artists": ["Stone Temple Pilots", "Scott Weiland"],
+  "created_at": "2021-05-09T21:58:15Z",
+  "updated_at": "2021-05-09T21:58:15Z"
+}
+```
+
+#### Bad Request
+```
+400 Bad Request
+Content-type: application/json; charset=utf-8
+
+{
+  "errors": {
+    "name": ["not_present"],
+    "duration": ["not_present", "not_numeric"],
+    "genre": ["not_present", "not_valid"],
+    "album_id": ["not_valid"],
+    "artist_id": ["not_valid"]
+  }
+}
+```
+

--- a/lib/presenters/base.rb
+++ b/lib/presenters/base.rb
@@ -1,0 +1,25 @@
+module Presenters
+  class Base
+    attr_accessor :object
+
+    def initialize(object)
+      @object = object
+    end
+
+    def render(object)
+      raise "You must implement this in your class"
+    end
+
+    def show
+      if @object.is_a?(Array)
+        [].tap do |p|
+          @object.each do |obj|
+            p << render(obj)
+          end
+        end
+      else
+        render(@object)
+      end
+    end
+  end
+end

--- a/lib/presenters/song.rb
+++ b/lib/presenters/song.rb
@@ -1,0 +1,18 @@
+require_relative "./base"
+
+module Presenters
+  class Song < Base
+    def render(object)
+      {
+        id: object.id,
+        name: object.name,
+        duration: object.duration,
+        genre: object.genre,
+        artists: object.artists&.map(&:name),
+        created_at: object.created_at.iso8601,
+        updated_at: object.updated_at.iso8601
+      }
+    end
+  end
+end
+

--- a/lib/validators/create_song.rb
+++ b/lib/validators/create_song.rb
@@ -1,0 +1,37 @@
+require "scrivener"
+
+module Validators
+  class CreateSong < Scrivener
+    attr_accessor :name, :duration, :genre, :albums, :artists
+
+    def validate
+      assert_present :name
+
+      if assert_present :duration
+        assert_numeric :duration
+      end
+
+      if assert_present :genre
+        assert_member :genre, Song.genres
+      end
+
+      if albums
+        assert albums.is_a?(Array), [:albums, :not_valid]
+
+        album_records = Album.where(id: albums)
+
+        assert album_records.size == albums.size, [:album_id, :not_valid]
+      end
+
+      if artists
+        if assert(artists.is_a?(Array), [:artists, :not_valid])
+          artists.each do |artist|
+            if artist[:id]
+              assert Artist.where(id: artist[:id]).any?, [:artist_id, :not_valid]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/controllers/songs_controller_test.rb
+++ b/test/controllers/songs_controller_test.rb
@@ -1,0 +1,163 @@
+require_relative "../test_helper"
+
+describe SongsController do
+  before do
+    @album = Album.spawn
+  end
+
+  it "should validate required attributes" do
+    params = {}
+
+    res = post("/songs", params)
+
+    assert_equal 400, res.status
+    assert_equal "application/json; charset=utf-8", res.headers["Content-type"]
+
+    body = JSON.parse(res.body)
+
+    assert_equal ["not_present"], body["errors"]["name"]
+    assert_equal ["not_present"], body["errors"]["duration"]
+    assert_equal ["not_present"], body["errors"]["genre"]
+  end
+
+  it "should validate album exists" do
+    artist = Artist.spawn
+
+    params = {
+      name: "Creep",
+      duration: 333,
+      genre: :alternative_rock,
+      albums: [@album.id, @album.id + 10],
+      artists: [{ id: artist.id }]
+    }
+
+    res = post("/songs", params)
+
+    assert_equal 400, res.status
+    assert_equal "application/json; charset=utf-8", res.headers["Content-type"]
+
+    body = JSON.parse(res.body)
+
+    assert_equal ["not_valid"], body["errors"]["album_id"]
+  end
+
+  it "should validate artist exists" do
+    params = {
+      name: "Wicked Garden",
+      duration: 245,
+      genre: :alternative_rock,
+      albums: [@album.id],
+      artists: [
+        { id: 0 }
+      ]
+    }
+
+    res = post("/songs", params)
+
+    assert_equal 400, res.status
+    assert_equal "application/json; charset=utf-8", res.headers["Content-type"]
+
+    body = JSON.parse(res.body)
+
+    assert_equal ["not_valid"], body["errors"]["artist_id"]
+  end
+
+  it "should create with artist" do
+    params = {
+      name: "Wicked Garden",
+      duration: 245,
+      genre: :alternative_rock,
+      albums: [@album.id],
+      artists: [
+        { name: "Stone Temple Pilots", biography: "Awesome American Rock Band" }
+      ]
+    }
+
+    artist_count = Artist.count
+    album_songs = @album.cached_songs || {}
+
+    res = post("/songs", params)
+
+    assert_equal 201, res.status
+    assert_equal "application/json; charset=utf-8", res.headers["Content-type"]
+
+
+    artist = Artist.find_by_name(params[:artists][0][:name])
+    @album.reload
+
+    body   = JSON.parse(res.body)
+
+    assert artist
+    assert_equal(artist_count + 1, Artist.count)
+    assert_equal(album_songs.size + 1, @album.cached_songs.size)
+
+    assert_equal params[:name], body["name"]
+    assert_equal params[:duration], body["duration"]
+    assert_equal params[:genre].to_s, body["genre"]
+
+    assert_equal [artist.name], body["artists"]
+  end
+
+  it "should associate with artist and album" do
+    album = Album.spawn(name: "Facelift", year: 1990, total_duration: 0)
+    artist = Artist.spawn(name: "Alice in Chains")
+
+    artist_count = Artist.count
+    album_songs = album.cached_songs || {}
+
+    params = {
+      name: "Man in the Box",
+      duration: 285,
+      genre: :alternative_rock,
+      albums: [album.id],
+      artists: [
+        { id: artist.id }
+      ]
+    }
+
+    res = post("/songs", params)
+
+    album.reload
+    artist.reload
+
+    assert_equal 201, res.status
+    assert_equal "application/json; charset=utf-8", res.headers["Content-type"]
+
+    body = JSON.parse(res.body)
+
+    assert_equal 1, album.cached_songs.size
+
+    assert_equal artist_count, Artist.count
+    assert_equal album_songs.size + 1, album.cached_songs.size
+
+    assert_equal params[:name], body["name"]
+    assert_equal params[:duration], body["duration"]
+    assert_equal params[:genre].to_s, body["genre"]
+    assert_equal params[:duration], album.total_duration
+    assert(artist.songs.map(&:id).include?(body["id"]))
+  end
+
+  it "should validate album exists" do
+    params = {
+      name: "Wicked Garden",
+      duration: 245,
+      genre: :alternative_rock,
+      albums: [-1],
+      artists: [
+        { id: 1 }
+      ]
+    }
+
+    refute Album.where(id: params[:albums][0]).any?
+
+    res = post("/songs", params)
+
+    assert_equal 400, res.status
+    assert_equal "application/json; charset=utf-8", res.headers["Content-type"]
+
+    body = JSON.parse(res.body)
+
+    assert_equal ["not_valid"], body["errors"]["album_id"]
+  end
+
+end

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -18,4 +18,30 @@ describe Album do
     assert_equal ["is not a number"], album.errors[:total_duration]
     assert_equal ["is not a number"], album.errors[:year]
   end
+
+  it "should update total duration" do
+    album = Album.spawn(name: "Core", cached_songs: {}, total_duration: 100)
+    artist = Artist.spawn(name: "Stone Temple Pilots", biography: "Fantastic rock band")
+    song = Song.spawn(name: "Plush", duration: 314, genre: :alternative_rock)
+
+    artist.songs << song
+
+    album.add_song(song)
+
+    assert_equal 414, album.total_duration
+  end
+
+  it "should cache song" do
+    album = Album.spawn(name: "Core", cached_songs: {}, total_duration: 100)
+    artist = Artist.spawn(name: "Stone Temple Pilots", biography: "Fantastic rock band")
+    song = Song.spawn(name: "Creep", duration: 333, genre: :alternative_rock)
+
+    artist.songs << song
+
+    album.add_song(song)
+
+    cached_song = { "name" => song.name, "duration" => song.duration, "genre" => song.genre, "artists" => song.artists.map(&:name) }
+
+    assert_equal cached_song, album.cached_songs[song.id.to_s]
+  end
 end

--- a/test/models/artist_test.rb
+++ b/test/models/artist_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ArtistTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/spawners.rb
+++ b/test/spawners.rb
@@ -1,0 +1,17 @@
+Album.extend(Spawn).spawner do |album|
+  album.name = "Core"
+  album.year = 1992
+  album.album_art = "https://en.wikipedia.org/wiki/Core_(Stone_Temple_Pilots_album)#/media/File:Stonetemplepilotscore.jpeg"
+  album.total_duration = 0
+end
+
+Artist.extend(Spawn).spawner do |artist|
+  artist.name = "Alice In Chains"
+  artist.biography = "Alice the greatest"
+end
+
+Song.extend(Spawn).spawner do |song|
+  song.name = "Plush"
+  song.duration = 314
+  song.genre = :alternative_rock
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,8 @@ require "minitest/spec"
 require "minitest/autorun"
 require "minitest/assertions"
 
+require_relative "./spawners"
+
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
   parallelize(workers: :number_of_processors)


### PR DESCRIPTION
This PR adds the `POST /songs` endpoint to allow song records creation.

It adds the [scoped-concerns](https://github.com/threefunkymonkeys/scoped-concerns) dependency to facilitate code encapsulation in tasks that involve many objects coordination and to provide a standard response format that can be handled in the same way among containers. It also helps code re-utilization.

For endpoint documentation take a look at `docs/songs.md`.

Note: Tests have been scoped down to controllers tests in general for simplicity's sake in this code challenge (with the exception of a couple model-specific methods that are tested in unit tests for models).